### PR TITLE
refactor: allow routes to be accessed only by the referenced user

### DIFF
--- a/prisma/seedData.ts
+++ b/prisma/seedData.ts
@@ -7,7 +7,7 @@ import { SeedData } from './ts/types';
 export const seedData: SeedData = {
   users: [
     {
-      id: TestIds.EXISTENT,
+      id: 1,
       name: 'John Doe',
       email: 'john@example.com',
       password: 'password12',
@@ -47,18 +47,18 @@ export const seedData: SeedData = {
       userId: 1,
     },
     {
-      id: 2,
+      id: TestIds.LINKED,
       amount: 75.5,
       dueDate: new Date('2023-10-24'),
       details: 'Internet bill for October',
       userId: 1,
     },
     {
-      id: 3,
+      id: TestIds.FOREIGN,
       amount: 200.0,
       dueDate: new Date('2023-10-23'),
       details: 'Rent for Apartment A',
-      userId: 1,
+      userId: 2,
     },
     {
       id: 4,
@@ -190,14 +190,14 @@ export const seedData: SeedData = {
       userId: 1,
     },
     {
-      id: 2,
+      id: TestIds.LINKED,
       amount: 50.5,
       dueDate: new Date('2023-10-24'),
       details: 'Consulting services - Client B',
       userId: 1,
     },
     {
-      id: 3,
+      id: TestIds.FOREIGN,
       amount: 75.0,
       dueDate: new Date('2023-10-23'),
       details: 'Graphic design work - Project C',

--- a/src/app/modules/bill/bill.controller.ts
+++ b/src/app/modules/bill/bill.controller.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/common';
 import { JwtAtGuard } from '../../../core/guards';
 import { BillService } from './bill.service';
+import { AuthenticatedUser } from '../../../core/decorators';
+import { User } from '@prisma/client';
 
 @Controller('bills')
 export class BillController {
@@ -15,19 +17,25 @@ export class BillController {
 
   @UseGuards(JwtAtGuard)
   @Get()
-  getBills() {
-    return this.billService.getBills();
+  getBills(@AuthenticatedUser() user: User) {
+    return this.billService.getBills(user);
   }
 
   @UseGuards(JwtAtGuard)
   @Get('/:id')
-  getBillById(@Param('id', ParseIntPipe) id: number) {
-    return this.billService.getBillById(id);
+  getBillById(
+    @AuthenticatedUser() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.billService.getBillById(user, id);
   }
 
   @UseGuards(JwtAtGuard)
   @Delete('/:id')
-  deleteBillById(@Param('id', ParseIntPipe) id: number) {
-    return this.billService.deleteBillById(id);
+  deleteBillById(
+    @AuthenticatedUser() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.billService.deleteBillById(user, id);
   }
 }

--- a/src/app/modules/bill/bill.service.ts
+++ b/src/app/modules/bill/bill.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Bill, Prisma } from '@prisma/client';
+import { Bill, Prisma, User } from '@prisma/client';
 import { PrismaService } from '../../../shared/prisma/prisma.service';
 
 @Injectable()
@@ -7,10 +7,13 @@ export class BillService {
   constructor(private prismaService: PrismaService) {}
 
   /**
-   * Retrieves all bills.
+   * Retrieves all bills that belong to the user.
    */
-  async getBills() {
+  async getBills(user: User) {
     return this.prismaService.bill.findMany({
+      where: {
+        userId: user.id,
+      },
       select: {
         id: true,
         amount: true,
@@ -20,12 +23,13 @@ export class BillService {
   }
 
   /**
-   * Retrieves a bill by id.
+   * Retrieves a bill by id, if it belongs to the user.
    */
-  async getBillById(id: number) {
+  async getBillById(user: User, id: number) {
     const bill = await this.prismaService.bill.findUnique({
       where: {
         id,
+        userId: user.id,
       },
     });
 
@@ -37,15 +41,16 @@ export class BillService {
   }
 
   /**
-   * Deletes a bill by id.
+   * Deletes a bill by id, if it belongs to the user.
    */
-  async deleteBillById(id: number) {
+  async deleteBillById(user: User, id: number) {
     let bill: Bill;
 
     try {
       bill = await this.prismaService.bill.delete({
         where: {
           id,
+          userId: user.id,
         },
       });
     } catch (e) {

--- a/src/app/modules/invoice/invoice.controller.ts
+++ b/src/app/modules/invoice/invoice.controller.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/common';
 import { InvoiceService } from './invoice.service';
 import { JwtAtGuard } from '../../../core/guards';
+import { AuthenticatedUser } from '../../../core/decorators';
+import { User } from '@prisma/client';
 
 @Controller('invoices')
 export class InvoiceController {
@@ -15,19 +17,25 @@ export class InvoiceController {
 
   @UseGuards(JwtAtGuard)
   @Get()
-  getInvoices() {
-    return this.invoiceService.getInvoices();
+  getInvoices(@AuthenticatedUser() user: User) {
+    return this.invoiceService.getInvoices(user);
   }
 
   @UseGuards(JwtAtGuard)
   @Get('/:id')
-  getInvoiceById(@Param('id', ParseIntPipe) id: number) {
-    return this.invoiceService.getInvoiceById(id);
+  getInvoiceById(
+    @AuthenticatedUser() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.invoiceService.getInvoiceById(user, id);
   }
 
   @UseGuards(JwtAtGuard)
   @Delete('/:id')
-  deleteInvoiceById(@Param('id', ParseIntPipe) id: number) {
-    return this.invoiceService.deleteInvoiceById(id);
+  deleteInvoiceById(
+    @AuthenticatedUser() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.invoiceService.deleteInvoiceById(user, id);
   }
 }

--- a/src/app/modules/invoice/invoice.service.ts
+++ b/src/app/modules/invoice/invoice.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Invoice, Prisma } from '@prisma/client';
+import { Invoice, Prisma, User } from '@prisma/client';
 import { PrismaService } from '../../../shared/prisma/prisma.service';
 
 @Injectable()
@@ -7,10 +7,13 @@ export class InvoiceService {
   constructor(private prismaService: PrismaService) {}
 
   /**
-   * Retrieves all invoices.
+   * Retrieves all invoices that belong to the user.
    */
-  async getInvoices() {
+  async getInvoices(user: User) {
     return this.prismaService.invoice.findMany({
+      where: {
+        userId: user.id,
+      },
       select: {
         id: true,
         amount: true,
@@ -20,12 +23,13 @@ export class InvoiceService {
   }
 
   /**
-   * Retrieves an invoice by it's id.
+   * Retrieves an invoice by it's id, if it belongs to the user.
    */
-  async getInvoiceById(id: number) {
+  async getInvoiceById(user: User, id: number) {
     const invoice = await this.prismaService.invoice.findUnique({
       where: {
         id,
+        userId: user.id,
       },
     });
 
@@ -37,15 +41,16 @@ export class InvoiceService {
   }
 
   /**
-   * Deletes an invoice by it's id.
+   * Deletes an invoice by it's id, if it belongs to the user.
    */
-  async deleteInvoiceById(id: number) {
+  async deleteInvoiceById(user: User, id: number) {
     let invoice: Invoice;
 
     try {
       invoice = await this.prismaService.invoice.delete({
         where: {
           id,
+          userId: user.id,
         },
       });
     } catch (e) {

--- a/src/ts/enums/testIds.enum.ts
+++ b/src/ts/enums/testIds.enum.ts
@@ -7,6 +7,14 @@ export enum TestIds {
    */
   EXISTENT = 1,
   /**
+   * A valid id that exists in the database, and the resource belongs to the user.
+   */
+  LINKED = 2,
+  /**
+   * A valid id that exists in the database, and the resource does not belong to the user.
+   */
+  FOREIGN = 3,
+  /**
    * An invalid id that does not exist in the database.
    */
   NON_EXISTENT = 99999,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -181,6 +181,15 @@ describe('App (e2e)', () => {
             .expectStatus(HttpStatus.NOT_FOUND);
         });
 
+        test('should throw if the resource does not belong to the user', () => {
+          return spec()
+            .get(`/bills/${TestIds.FOREIGN}`)
+            .withHeaders({
+              Authorization: `Bearer $S{access_token}`,
+            })
+            .expectStatus(HttpStatus.NOT_FOUND);
+        });
+
         test('should return the resource', () => {
           return spec()
             .get(`/bills/${TestIds.EXISTENT}`)
@@ -201,6 +210,15 @@ describe('App (e2e)', () => {
         test('should throw if the resource does not exist', () => {
           return spec()
             .delete(`/bills/${TestIds.NON_EXISTENT}`)
+            .withHeaders({
+              Authorization: `Bearer $S{access_token}`,
+            })
+            .expectStatus(HttpStatus.NOT_FOUND);
+        });
+
+        test('should throw if the resource does not belong to the user', () => {
+          return spec()
+            .delete(`/bills/${TestIds.FOREIGN}`)
             .withHeaders({
               Authorization: `Bearer $S{access_token}`,
             })
@@ -252,6 +270,15 @@ describe('App (e2e)', () => {
             .expectStatus(HttpStatus.NOT_FOUND);
         });
 
+        test('should throw if the resource does not belong to the user', () => {
+          return spec()
+            .get(`/invoices/${TestIds.FOREIGN}`)
+            .withHeaders({
+              Authorization: `Bearer $S{access_token}`,
+            })
+            .expectStatus(HttpStatus.NOT_FOUND);
+        });
+
         test('should return the resource', () => {
           return spec()
             .get(`/invoices/${TestIds.EXISTENT}`)
@@ -272,6 +299,15 @@ describe('App (e2e)', () => {
         test('should throw if the resource does not exist', () => {
           return spec()
             .delete(`/invoices/${TestIds.NON_EXISTENT}`)
+            .withHeaders({
+              Authorization: `Bearer $S{access_token}`,
+            })
+            .expectStatus(HttpStatus.NOT_FOUND);
+        });
+
+        test('should throw if the resource does not belong to the user', () => {
+          return spec()
+            .delete(`/invoices/${TestIds.FOREIGN}`)
             .withHeaders({
               Authorization: `Bearer $S{access_token}`,
             })


### PR DESCRIPTION
This PR adds bare-bones support for the following routes, making them accessible only to the user that's being referenced to the resource:
- `GET /bills/:id`
- `DELETE /bills/:id`
- `GET /invoices/:id`
- `DELETE /invoices/:id`

*Note: Must've overlooked this requirement while reading the assessment details.*